### PR TITLE
Latest upstream 3.1.2

### DIFF
--- a/0001-Update-tests-of-serializing-ArrayObject-for-7.4.6.patch
+++ b/0001-Update-tests-of-serializing-ArrayObject-for-7.4.6.patch
@@ -1,0 +1,66 @@
+From 07de7a665802ff8e028b85442568031ae9759077 Mon Sep 17 00:00:00 2001
+From: Tyson Andre <tysonandre775@hotmail.com>
+Date: Wed, 6 May 2020 09:57:04 -0400
+Subject: [PATCH] Update tests of serializing ArrayObject for 7.4.6+
+
+Fixes #274
+---
+ tests/__serialize_012.phpt | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/tests/__serialize_012.phpt b/tests/__serialize_012.phpt
+index 13f1d32..488a87d 100644
+--- a/tests/__serialize_012.phpt
++++ b/tests/__serialize_012.phpt
+@@ -1,7 +1,7 @@
+ --TEST--
+ Test unserialization of classes derived from ArrayIterator
+ --SKIPIF--
+-<?php if (PHP_VERSION_ID < 70400) { echo "Skip requires php 7.4+"; } ?>
++<?php if (PHP_VERSION_ID < 70406) { echo "Skip requires php 7.4.6+"; } ?>
+ --FILE--
+ <?php
+ // based on bug45706.phpt from php-src
+@@ -12,13 +12,25 @@ class Foo2 {
+ }
+ $x = array(new Foo1(),new Foo2);
+ $s = igbinary_serialize($x);
++var_dump(igbinary_unserialize($s));
+ $s = str_replace("Foo", "Bar", $s);
+ $y = igbinary_unserialize($s);
+ var_dump($y);
+ --EXPECTF--
+ array(2) {
+   [0]=>
+-  object(__PHP_Incomplete_Class)#3 (4) {
++  object(Foo1)#3 (1) {
++    ["storage":"ArrayIterator":private]=>
++    array(0) {
++    }
++  }
++  [1]=>
++  object(Foo2)#4 (0) {
++  }
++}
++array(2) {
++  [0]=>
++  object(__PHP_Incomplete_Class)#4 (5) {
+     ["__PHP_Incomplete_Class_Name"]=>
+     string(4) "Bar1"
+     ["0"]=>
+@@ -29,9 +41,11 @@ array(2) {
+     ["2"]=>
+     array(0) {
+     }
++    ["3"]=>
++    NULL
+   }
+   [1]=>
+-  object(__PHP_Incomplete_Class)#4 (1) {
++  object(__PHP_Incomplete_Class)#3 (1) {
+     ["__PHP_Incomplete_Class_Name"]=>
+     string(4) "Bar2"
+   }
+-- 
+2.26.2
+

--- a/php74-pecl-igbinary.spec
+++ b/php74-pecl-igbinary.spec
@@ -17,14 +17,13 @@
 %global ini_name   40-%{pecl_name}.ini
 %global php        php74
 
-%global upstream_version 3.0.1
-#global upstream_prever  RC1
-
 Summary:        Replacement for the standard PHP serializer
 Name:           %{php}-pecl-%{pecl_name}
-Version:        %{upstream_version}%{?upstream_prever:~%{upstream_prever}}
-Release:        3%{?dist}
-Source0:        https://pecl.php.net/get/%{pecl_name}-%{upstream_version}%{?upstream_prever}.tgz
+Version:        3.1.2
+Release:        1%{?dist}
+Source0:        https://pecl.php.net/get/%{pecl_name}-%{version}.tgz
+# https://github.com/igbinary/igbinary/pull/275
+Patch0:         0001-Update-tests-of-serializing-ArrayObject-for-7.4.6.patch
 License:        BSD
 
 URL:            https://pecl.php.net/package/igbinary
@@ -76,17 +75,19 @@ These are the files needed to compile programs using Igbinary
 
 %prep
 %setup -q -c
-mv %{pecl_name}-%{upstream_version}%{?upstream_prever} NTS
+mv %{pecl_name}-%{version} NTS
 
 sed -e '/COPYING/s/role="doc"/role="src"/' -i package.xml
 
 cd NTS
 
+%patch0 -p 1
+
 # Check version
 subdir="php$(%{__php} -r 'echo PHP_MAJOR_VERSION;')"
 extver=$(sed -n '/#define PHP_IGBINARY_VERSION/{s/.* "//;s/".*$//;p}' src/$subdir/igbinary.h)
-if test "x${extver}" != "x%{upstream_version}%{?upstream_prever}"; then
-   : Error: Upstream version is ${extver}, expecting %{upstream_version}%{?upstream_prever}.
+if test "x${extver}" != "x%{version}"; then
+   : Error: Upstream version is ${extver}, expecting %{version}.
    exit 1
 fi
 cd ..
@@ -231,6 +232,10 @@ fi
 
 
 %changelog
+* Wed Jun 10 2020 Carl George <carl@george.computer> - 3.1.2-1
+- Latest upstream
+- Add patch0 to fix failing test
+
 * Fri Jun 05 2020 David Alger <davidmalger@gmail.com> - 3.0.1-3
 - Port from Fedora to IUS
 


### PR DESCRIPTION
Per the discussion in https://github.com/iusrepo/wishlist/issues/276, I looked into the failing tests.  Between upstream 3.1.2 and [this upstream commit](https://github.com/igbinary/igbinary/commit/07625b9a51a96d8402fd01b373edd58befa4e3fb), I was able to get a good build with all tests passing.